### PR TITLE
feat: replace caip-x with caip-348

### DIFF
--- a/src/transports/constants.ts
+++ b/src/transports/constants.ts
@@ -1,1 +1,1 @@
-export const REQUEST_CAIP = 'caip-x';
+export const REQUEST_CAIP = 'caip-348';


### PR DESCRIPTION
replaces `caip-x` with `caip-348` in the envelope for the Multichain API over externally_connectable

see: https://github.com/MetaMask/metamask-extension/pull/32070