### PR TITLE
Make getMultichainClient synchronous

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ or
 ```typescript
 import { getMultichainClient, getDefaultTransport } from '@metamask/multichain-api-client';
 
-const client = await getMultichainClient({ transport: getDefaultTransport() });
+const client = getMultichainClient({ transport: getDefaultTransport() });
 const session = await client.createSession({ requiredScopes: ['eip155:1'] });
 
 const result = await client.invokeMethod({

--- a/src/multichainClient.test.ts
+++ b/src/multichainClient.test.ts
@@ -5,7 +5,7 @@ import { getMultichainClient } from './multichainClient';
 const mockTransport = getMockTransport();
 describe('getMultichainClient', () => {
   it('should create a client with all required methods', async () => {
-    const client = await getMultichainClient({ transport: mockTransport });
+    const client = getMultichainClient({ transport: mockTransport });
 
     expect(client).toBeDefined();
     expect(client.createSession).toBeDefined();
@@ -15,7 +15,7 @@ describe('getMultichainClient', () => {
   });
 
   it('should create a session successfully', async () => {
-    const client = await getMultichainClient({ transport: mockTransport });
+    const client = getMultichainClient({ transport: mockTransport });
     const params = { optionalScopes: mockScope };
     const result = await client.createSession(params);
 
@@ -27,7 +27,7 @@ describe('getMultichainClient', () => {
   });
 
   it('should get session successfully', async () => {
-    const client = await getMultichainClient({ transport: mockTransport });
+    const client = getMultichainClient({ transport: mockTransport });
     const result = await client.getSession();
 
     expect(result).toEqual(mockSession);
@@ -38,7 +38,7 @@ describe('getMultichainClient', () => {
 
   describe('revokeSession', () => {
     it('should revoke session successfully', async () => {
-      const client = await getMultichainClient({ transport: mockTransport });
+      const client = getMultichainClient({ transport: mockTransport });
       await client.revokeSession();
 
       expect(mockTransport.request).toHaveBeenCalledWith({
@@ -47,7 +47,7 @@ describe('getMultichainClient', () => {
     });
 
     it('should disconnect transport after revoking session', async () => {
-      const client = await getMultichainClient({ transport: mockTransport });
+      const client = getMultichainClient({ transport: mockTransport });
       await client.revokeSession();
 
       expect(mockTransport.disconnect).toHaveBeenCalled();
@@ -55,7 +55,7 @@ describe('getMultichainClient', () => {
   });
 
   it('should invoke methods successfully', async () => {
-    const client = await getMultichainClient({ transport: mockTransport });
+    const client = getMultichainClient({ transport: mockTransport });
 
     // Test signAndSendTransaction
     const signAndSendResult = await client.invokeMethod({
@@ -112,7 +112,7 @@ describe('getMultichainClient', () => {
       isConnected: mockIsConnected,
     };
 
-    const client = await getMultichainClient({ transport });
+    const client = getMultichainClient({ transport });
     await client.getSession();
 
     expect(mockIsConnected).toHaveBeenCalled();

--- a/src/multichainClient.ts
+++ b/src/multichainClient.ts
@@ -58,11 +58,9 @@ export function getMultichainClient<T extends RpcApi = DefaultRpcApi>({
       });
     },
     revokeSession: async () => {
-      try {
-        await transport.request({ method: 'wallet_revokeSession' });
-      } finally {
-        await transport.disconnect();
-      }
+      await ensureConnected();
+      await transport.request({ method: 'wallet_revokeSession' });
+      await transport.disconnect();
     },
     invokeMethod: async <S extends Scope<T>, M extends MethodName<T, S>>(
       params: InvokeMethodParams<T, S, M>,

--- a/tests/index.test-d.ts
+++ b/tests/index.test-d.ts
@@ -2,7 +2,7 @@ import { expectError, expectType } from 'tsd';
 import { getMultichainClient } from '../src/index';
 import { getMockTransport } from './mocks';
 
-const client = await getMultichainClient({ transport: getMockTransport() });
+const client = getMultichainClient({ transport: getMockTransport() });
 
 // ==========================================
 // Test successful method calls


### PR DESCRIPTION
This PR makes `getMultichainClient` synchronous, to allow faster Wallet Standard registration