### PR TITLE
feat: allow partial revokes via `wallet_revokeSession`

### DIFF
--- a/src/multichainClient.test.ts
+++ b/src/multichainClient.test.ts
@@ -39,16 +39,17 @@ describe('getMultichainClient', () => {
   describe('revokeSession', () => {
     it('should revoke session successfully', async () => {
       const client = getMultichainClient({ transport: mockTransport });
-      await client.revokeSession();
+      await client.revokeSession({});
 
       expect(mockTransport.request).toHaveBeenCalledWith({
         method: 'wallet_revokeSession',
+        params: {},
       });
     });
 
     it('should disconnect transport after revoking session', async () => {
       const client = getMultichainClient({ transport: mockTransport });
-      await client.revokeSession();
+      await client.revokeSession({});
 
       expect(mockTransport.disconnect).toHaveBeenCalled();
     });

--- a/src/multichainClient.ts
+++ b/src/multichainClient.ts
@@ -7,6 +7,7 @@ import type {
   MultichainApiMethod,
   MultichainApiParams,
   MultichainApiReturn,
+  RevokeSessionParams,
 } from './types/multichainApi';
 import type { DefaultRpcApi, MethodName, MethodReturn, RpcApi, Scope } from './types/scopes';
 import type { SessionData } from './types/session';
@@ -84,11 +85,11 @@ export function getMultichainClient<T extends RpcApi = DefaultRpcApi>({
       await ensureInitialized();
       return await request({ transport, method: 'wallet_getSession' });
     },
-    revokeSession: async () => {
+    revokeSession: async (params?: RevokeSessionParams<T>) => {
       await ensureInitialized();
       initializationPromise = undefined;
       connectionPromise = undefined;
-      await request({ transport, method: 'wallet_revokeSession' });
+      await request({ transport, method: 'wallet_revokeSession', params });
       await transport.disconnect();
     },
     invokeMethod: async <S extends Scope<T>, M extends MethodName<T, S>>(

--- a/src/types/multichainApi.ts
+++ b/src/types/multichainApi.ts
@@ -68,7 +68,7 @@ export type MultichainApiClient<T extends RpcApi = DefaultRpcApi> = {
 export type MultichainApi<T extends RpcApi> = {
   wallet_createSession: RpcMethod<CreateSessionParams<T>, SessionData>;
   wallet_getSession: RpcMethod<void, SessionData | undefined>;
-  wallet_revokeSession: RpcMethod<void, void>;
+  wallet_revokeSession: RpcMethod<RevokeSessionParams<T>, void>;
   wallet_invokeMethod: <S extends Scope<T>, M extends MethodName<T, S>>(
     params: InvokeMethodParams<T, S, M>,
   ) => MethodReturn<T, S, M>;
@@ -79,6 +79,11 @@ export type CreateSessionParams<T extends RpcApi> = {
   requiredScopes?: Record<Scope<T>, ScopeObject>;
   optionalScopes?: Record<Scope<T>, ScopeObject>;
   sessionProperties?: SessionProperties;
+};
+
+// wallet_revokeSession params
+export type RevokeSessionParams<T extends RpcApi> = {
+  sessionScopes?: Scope<T>[]
 };
 
 // wallet_invokeMethod params


### PR DESCRIPTION
<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues or other links reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

## Explanation

Uniswap reported a bug in slack [here](https://consensys.slack.com/archives/C017NBJL1S7/p1758234734587359?thread_ts=1752698865.023109&cid=C017NBJL1S7) where MetaMask was unpermitting any EVM connections for a dapp if that dapp used the solana wallet standard provider to make a connect request and then cancelled it.

This call to `disconnect()` is happening outside of our packages and is not related to a previous but similar bug where our own wallet-standard provider was calling `wallet_revokeSession` when receiving an empty solana `accountsChanged` event.

To fix this, this PR proposes an implementation for partial permission revoking in the `wallet_revokeSession` handler so that we can then update our solana `wallet-standard` provider to only revoke the solana scopes when it is asked to disconnect. 

## References

* Fixes [#728](https://consensyssoftware.atlassian.net/browse/WAPI-728)