### PR TITLE
feat: Export scopes types

### DIFF
--- a/src/types/scopes/index.ts
+++ b/src/types/scopes/index.ts
@@ -37,3 +37,8 @@ export type DefaultRpcApi = {
   bip122: Bip122Rpc;
   tron: TronRpc;
 };
+
+export type * as EIP155Scope from './eip155.types';
+export type * as SolanaScope from './solana.types';
+export type * as BIP122Scope from './bip122.types';
+export type * as TronScope from './tron.types';


### PR DESCRIPTION
<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues or other links reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk type-only change that expands the public type surface by re-exporting scope definitions; potential risk is minor breaking/duplication in consumers’ type imports.
> 
> **Overview**
> Re-exports the chain-specific scope type modules (`eip155.types`, `solana.types`, `bip122.types`, `tron.types`) from `src/types/scopes/index.ts` as namespaced type exports (e.g., `EIP155Scope`). This makes the per-scope type definitions directly importable from the scopes index without changing any runtime behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 977af02e7deafe181e4528ab77cb6b7dbac2eaba. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->