### PR TITLE
feat: re-export per-scope types from package root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- feat: re-export per-scope types (`bip122`, `eip155`, `solana`, `tron`) from the package root so consumers can import named types like `TronAddress`, `Eip155Rpc`, etc. directly instead of going through `MethodParams<DefaultRpcApi, ...>`
+
 ## [0.11.0]
 
 ### Added

--- a/src/types/scopes/index.ts
+++ b/src/types/scopes/index.ts
@@ -3,6 +3,11 @@ import type { Eip155Rpc } from './eip155.types';
 import type { SolanaRpc } from './solana.types';
 import type { TronRpc } from './tron.types';
 
+export type * from './bip122.types';
+export type * from './eip155.types';
+export type * from './solana.types';
+export type * from './tron.types';
+
 export type RpcApi = Record<
   string,
   {


### PR DESCRIPTION
## What is the current state of things and why does it need to change?

`src/types/scopes/index.ts` imports `Bip122Rpc`, `Eip155Rpc`, `SolanaRpc`, `TronRpc` to compose `DefaultRpcApi`, but it never re-exports anything from those `*.types.ts` files. The package root (`src/index.ts`) then does `export type * from './types/scopes'`, so all the per-chain named types (`TronAddress`, `Base64Message`, `Signature`, `SignMessageMethod`, `SignTransactionMethod`, `TronRpc`, `Eip155Rpc`, `Address`, `HexString`, `Transaction`, `TransactionReceipt`, `Commitment`, `SolanaRpc`, `Bip122Rpc`, …) are unreachable from the package root.

Consumers currently have to either:

1. Use the indirect helpers — `MethodParams<DefaultRpcApi, \`tron:${string}\`, 'signMessage'>` — to recover something equivalent to `SignMessageMethod`'s params.
2. Reach into `@metamask/multichain-api-client/dist/types/scopes/tron.types`, which is blocked by the package's `exports` field in modern resolution modes.

Real-world example: [`metamask-mobile`'s WalletConnect Tron bridge](https://github.com/MetaMask/metamask-mobile) wants to type its Snap-bound request as `MethodParams<DefaultRpcApi, \`tron:${string}\`, 'signMessage'>` for compile-time alignment with this package's contract. It works, but `import type { TronAddress, Base64Message } from '@metamask/multichain-api-client'` would read a lot better.

## What is the solution your changes offer and how does it work?

Add four `export type *` lines to `src/types/scopes/index.ts`, one per chain. Purely additive, no runtime impact, no public API removed.

After this change, all named exports from `bip122.types.ts`, `eip155.types.ts`, `solana.types.ts`, `tron.types.ts` become accessible from the package root.

### Checked

- No name collisions across the four scope files (verified by grepping all `export ` declarations under `src/`).
- `yarn build` — declarations regenerated, `dist/types/scopes/index.d.{mts,cts}` now contain the re-exports.
- `yarn test` — vitest + `attw` (Are The Types Wrong) + tsd type tests pass.
- `yarn lint` — biome + depcheck + dedupe + changelog all clean.

### Considered alternatives

- Only re-exporting `tron.types` (my immediate use case) — rejected as inconsistent; the same gap exists for the three other scopes.
- Adding a deep-import subpath via `exports` — heavier API surface change, doesn't help bundler users.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, type-only re-exports plus a changelog entry; no runtime behavior changes. Main risk is potential TypeScript export name collisions or downstream type resolution differences.
> 
> **Overview**
> Makes per-scope named types for `bip122`, `eip155`, `solana`, and `tron` available from the package root by adding `export type *` re-exports in `src/types/scopes/index.ts`.
> 
> Updates `CHANGELOG.md` to document the new type export surface so consumers can import types like `TronAddress`/`Eip155Rpc` directly instead of deriving them via `MethodParams<DefaultRpcApi, ...>`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1fe65e01b9e730940a693036f2e7333132908124. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->