### PR TITLE
chore: added stellar types, mock tests and exports

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -37,5 +37,6 @@ export type * from './types/transport';
 export type * from './types/session';
 export type * from './types/multichainApi';
 export type * from './types/scopes';
+export type { Base64Xdr, Sep43SignOptions, StellarAddress, StellarRpc } from './types/scopes/stellar.types';
 export * from './types/errors';
 export { isMetamaskInstalled } from './helpers/metamask';

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,6 +37,5 @@ export type * from './types/transport';
 export type * from './types/session';
 export type * from './types/multichainApi';
 export type * from './types/scopes';
-export type { Base64Xdr, Sep43SignOptions, StellarAddress, StellarRpc } from './types/scopes/stellar.types';
 export * from './types/errors';
 export { isMetamaskInstalled } from './helpers/metamask';

--- a/src/types/scopes/index.ts
+++ b/src/types/scopes/index.ts
@@ -1,6 +1,7 @@
 import type { Bip122Rpc } from './bip122.types';
 import type { Eip155Rpc } from './eip155.types';
 import type { SolanaRpc } from './solana.types';
+import type { StellarRpc } from './stellar.types';
 import type { TronRpc } from './tron.types';
 
 export type RpcApi = Record<
@@ -36,9 +37,11 @@ export type DefaultRpcApi = {
   solana: SolanaRpc;
   bip122: Bip122Rpc;
   tron: TronRpc;
+  stellar: StellarRpc;
 };
 
 export type * as EIP155Scope from './eip155.types';
 export type * as SolanaScope from './solana.types';
 export type * as BIP122Scope from './bip122.types';
 export type * as TronScope from './tron.types';
+export type * as StellarScope from './stellar.types';

--- a/src/types/scopes/stellar.types.ts
+++ b/src/types/scopes/stellar.types.ts
@@ -1,0 +1,58 @@
+import type { RpcMethod } from '.';
+
+/**
+ * A Stellar account address (StrKey), starting with 'G'.
+ * @example "GDQP2KPQGKIHYJOXNFPZMGLOJMPGADKZPQRBXF4ZZPRB6M3FQB6OGQ3G"
+ */
+export type StellarAddress = `G${string}`;
+
+/**
+ * Base64-encoded Stellar XDR.
+ */
+export type Base64Xdr = string;
+
+/**
+ * SEP-0043 signing options shared by message, transaction, and auth-entry signing.
+ * @see https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0043.md
+ */
+export type Sep43SignOptions = {
+  networkPassphrase?: string;
+  address?: string | null;
+};
+
+/**
+ * Signs a transaction envelope XDR and returns the signed XDR together with the signer address.
+ */
+export type SignTransactionMethod = RpcMethod<
+  { xdr: Base64Xdr; opts?: Sep43SignOptions },
+  { signedTxXdr: Base64Xdr; signerAddress: StellarAddress }
+>;
+
+/**
+ * Signs a Soroban `SorobanAuthorizationEntry` XDR and returns the signed entry with the signer address.
+ */
+export type SignAuthEntryMethod = RpcMethod<
+  { authEntry: Base64Xdr; opts?: Sep43SignOptions },
+  { signedAuthEntry: Base64Xdr | null; signerAddress: StellarAddress }
+>;
+
+/**
+ * Signs an arbitrary UTF-8 message and returns the base64-encoded signature with the signer address.
+ */
+export type SignMessageMethod = RpcMethod<
+  { message: string; opts?: Sep43SignOptions },
+  { signedMessage: string; signerAddress: StellarAddress }
+>;
+
+/**
+ * RPC API for the Stellar namespace (`stellar:pubnet`, etc.) via `wallet_invokeMethod`.
+ * Each method follows the SEP-0043 request/response shape.
+ */
+export type StellarRpc = {
+  methods: {
+    signTransaction: SignTransactionMethod;
+    signAuthEntry: SignAuthEntryMethod;
+    signMessage: SignMessageMethod;
+  };
+  events: [];
+};

--- a/src/types/session.ts
+++ b/src/types/session.ts
@@ -12,6 +12,7 @@ export type CaipAccountId = `${string}:${string}:${string}`;
  *  - `eip155:1`
  *  - `solana:mainnet`
  *  - `tron:728126428`
+ *  - `stellar:pubnet`
  */
 export type CaipChainId = `${string}:${string}`;
 

--- a/tests/index.test-d.ts
+++ b/tests/index.test-d.ts
@@ -1,6 +1,7 @@
 import { expectError, expectType } from 'tsd';
 import { getMultichainClient } from '../src/index';
 import type { Signature } from '../src/types/scopes/tron.types';
+import type { StellarAddress } from '../src/types/scopes/stellar.types';
 import { getMockTransport } from './mocks';
 
 const client = getMultichainClient({ transport: getMockTransport() });
@@ -56,6 +57,19 @@ expectType<{ signature: Signature }>(
       params: {
         address: 'TJRabPrwbZy45sbavfcjinPJC18kjpRTv8',
         message: 'aGVsbG8gd29ybGQ=',
+      },
+    },
+  }),
+);
+
+// Basic stellar signMessage call with correct scope and parameters
+expectType<{ signedMessage: string; signerAddress: StellarAddress }>(
+  await client.invokeMethod({
+    scope: 'stellar:pubnet',
+    request: {
+      method: 'signMessage',
+      params: {
+        message: 'Hello Stellar',
       },
     },
   }),
@@ -122,6 +136,19 @@ expectError(
       params: {
         address: '1234567890',
         message: 'message',
+      },
+    },
+  }),
+);
+
+// Invalid stellar parameter structure
+expectError(
+  await client.invokeMethod({
+    scope: 'stellar:pubnet',
+    request: {
+      method: 'signMessage',
+      params: {
+        xdr: 'not-a-message-param',
       },
     },
   }),


### PR DESCRIPTION
[PR SUMMARY]

- Added Stellar scope types (stellar.types.ts) & exports
- Wire stellar into DefaultRpcApi + exports
- Add tsd tests for stellar:pubnet
- Doc: stellar:pubnet example in session.ts (comment only)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are TypeScript type additions/exports plus tsd type tests, with no runtime logic or security-sensitive code modified.
> 
> **Overview**
> Adds a new `stellar` scope to the typed RPC surface by introducing `stellar.types.ts` (SEP-0043-shaped `signTransaction`, `signAuthEntry`, `signMessage`) and wiring it into `DefaultRpcApi`/scope exports.
> 
> Updates documentation comments to include `stellar:pubnet` as a valid CAIP chain id example and extends `tsd` coverage with positive/negative `invokeMethod` type checks for the new Stellar scope.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a1f140af87e4415f9da146c32c594f094aa6b82. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->