### PR TITLE
Revert release 0.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.12.0]
-
-### Uncategorized
-
-- fix: lint ([#103](https://github.com/MetaMask/multichain-api-client/pull/103))
-- chore: added stellar types, mock tests and exports ([#102](https://github.com/MetaMask/multichain-api-client/pull/102))
-- feat: Export scopes types
-
 ## [0.11.0]
 
 ### Added
@@ -144,8 +136,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release
 
-[Unreleased]: https://github.com/MetaMask/multichain-api-client/compare/v0.12.0...HEAD
-[0.12.0]: https://github.com/MetaMask/multichain-api-client/compare/v0.11.0...v0.12.0
+[Unreleased]: https://github.com/MetaMask/multichain-api-client/compare/v0.11.0...HEAD
 [0.11.0]: https://github.com/MetaMask/multichain-api-client/compare/v0.10.1...v0.11.0
 [0.10.1]: https://github.com/MetaMask/multichain-api-client/compare/v0.10.0...v0.10.1
 [0.10.0]: https://github.com/MetaMask/multichain-api-client/compare/v0.9.0...v0.10.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.12.0]
 
-### Added
-
-- chore: added stellar types, mock tests and exports ([#102](https://github.com/MetaMask/multichain-api-client/pull/102))
-
-### Fixed
+### Uncategorized
 
 - fix: lint ([#103](https://github.com/MetaMask/multichain-api-client/pull/103))
+- chore: added stellar types, mock tests and exports ([#102](https://github.com/MetaMask/multichain-api-client/pull/102))
+- feat: Export scopes types
 
 ## [0.11.0]
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/multichain-api-client",
-  "version": "0.12.0",
+  "version": "0.11.0",
   "license": "ISC",
   "description": "MetaMask Multichain Api Client",
   "homepage": "https://github.com/MetaMask/multichain-api-client#readme",


### PR DESCRIPTION
<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues or other links reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and version metadata only; no runtime or API behavior changes in the diff.
> 
> **Overview**
> **Reverts the 0.12.0 release** by rolling the published package version back to **0.11.0** in `package.json` and aligning release notes in `CHANGELOG.md`.
> 
> The **0.12.0** section (Stellar types/mocks/exports and a lint fix) is removed from the changelog, and compare links at the bottom now treat **Unreleased** as `v0.11.0...HEAD` instead of `v0.12.0...HEAD`. No library source or API code is changed in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 105fd677178d0e4f08cb5074adac7d7cac745cb7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->